### PR TITLE
[IMP] Add to Schemas a convenience Odoo env

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ parse-accept-language
 jsondiff
 graphene
 graphql-server-core
-marshmallow
+marshmallow==3.2.2
 marshmallow-objects>=2.0.0
 apispec


### PR DESCRIPTION
This adds a convenience Env to the Schemas behind the datamodels.

Benefits include:
- easily being able to keep all validation logic on datamodels, in consistent style with Odoo. For example, it is very easy to check values in @validates functions against in-db values 
- you could create a new record from validated data in a @post_load function

Potential drawbacks:
- the env is made with superuser id. Wrong or convoluted usage can lead to suspension of access rules
- adds modification on the Schema level, might be a cleaner way (?)