### PR TITLE
[FIX] fix issue when starting odoo

### DIFF
--- a/base_rest/models/__init__.py
+++ b/base_rest/models/__init__.py
@@ -1,1 +1,2 @@
 from . import rest_service_registration
+from . import builder

--- a/base_rest/models/builder.py
+++ b/base_rest/models/builder.py
@@ -1,0 +1,20 @@
+# Copyright 2020 Akretion (https://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class ComponentBuilder(models.AbstractModel):
+    _inherit = "component.builder"
+
+    @api.model_cr
+    def _register_hook(self):
+        super()._register_hook()
+        # The order for calling the "_register_hook" on model is random
+        # Indeed the Environment is a collections.abc.Mapping
+        # that is not ordered and so the order is random
+        # The build of the registry service must be done after the build
+        # of "component.builder" so we call manually here the build after
+        # calling super
+        self.env["rest.service.registration"]._register_registry()

--- a/base_rest/models/rest_service_registration.py
+++ b/base_rest/models/rest_service_registration.py
@@ -44,7 +44,7 @@ class RestServiceRegistation(models.AbstractModel):
     _description = "REST Services Registration Model"
 
     @api.model_cr
-    def _register_hook(self):
+    def _register_registry(self):
         # This method is called by Odoo when the registry is built,
         # so in case the registry is rebuilt (cache invalidation, ...),
         # we have to to rebuild the registry. We use a new


### PR DESCRIPTION
The order for calling the "_register_hook" on model is random
Indeed the Environment is a collections.abc.Mapping
that is not ordered and so the order is random
The build of the registry service must be done after the build
of "component.builder" so we call manually here the build after
calling super

@lmignon @sbidoul 